### PR TITLE
Revert "Update Version."

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.2-rtl.2",
+  "version": "1.3.2",
   "codename": "france",
   "date": "2017-08-23",
   "time": "06:42:58"


### PR DESCRIPTION
This reverts commit 492f12f4762f609cbda7e69dcb715f971baa750c.

No need to update version.

Current tag name (**1.3.2-rtl.2**) is incorrect, it should be **v1.3.2-rtl.2**.